### PR TITLE
Replace run-gem-dev with runfile-tasks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,5 @@
 source "https://rubygems.org"
 
-
 group :test do
   gem 'rails'
   gem 'sqlite3'

--- a/Runfile
+++ b/Runfile
@@ -1,4 +1,4 @@
-require "run-gem-dev"
+require "runfile-tasks"
 include Runfile::Exec
 
 name     "PunditExtra Dev Tools"
@@ -10,8 +10,5 @@ action  :s, :server do
   run "rackup"
 end
 
-# `run gem *` tasks
-RunGemDev::gem_tasks 'pundit_extra'
-
-# `run spec` tasks
-RunGemDev::rspec_tasks
+RunfileTasks::RubyGems.all 'pundit_extra'
+RunfileTasks::Testing.rspec

--- a/pundit_extra.gemspec
+++ b/pundit_extra.gemspec
@@ -17,5 +17,5 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "combustion", "~> 0.5"
   s.add_development_dependency "runfile", "~> 0.6"
-  s.add_development_dependency "run-gem-dev", "~> 0.3"
+  s.add_development_dependency 'runfile-tasks', '~> 0.4'
 end


### PR DESCRIPTION
This is only relevant for development mode.
No change in Runfile command, since runfile-tasks is the successor of run-gem-dev.

We will not compile a new gem at this point.
