### PR TITLE
Update runfile to run without bundle exec

### DIFF
--- a/Runfile
+++ b/Runfile
@@ -1,5 +1,5 @@
 require "runfile-tasks"
-include Runfile::Exec
+require_relative 'lib/pundit_extra'
 
 name     "PunditExtra Dev Tools"
 summary  "Utilities for the gem developer"

--- a/lib/pundit_extra.rb
+++ b/lib/pundit_extra.rb
@@ -1,3 +1,4 @@
 require "pundit_extra/controller_mixin"
 require "pundit_extra/helpers"
 require "pundit_extra/resource_autoload"
+require "pundit_extra/version"

--- a/pundit_extra.gemspec
+++ b/pundit_extra.gemspec
@@ -16,6 +16,6 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 2.0.0"
 
   s.add_development_dependency "combustion", "~> 0.5"
-  s.add_development_dependency "runfile", "~> 0.6"
+  s.add_development_dependency "runfile", "~> 0.7"
   s.add_development_dependency 'runfile-tasks', '~> 0.4'
 end


### PR DESCRIPTION
This PR has no impact on the actual gem, its only a minor fix for development purposes.

In some situations `run` did not work as expected.
Also updated dev dependencies to use Runfile 0.7.x
